### PR TITLE
Merge pull request #27 from MarcPujolUNI/26-fixdocker-remove-media-folder-from-dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,7 +26,6 @@ dist/
 
 # Static / media build folders (si es re-generen en collectstatic)
 staticfiles/
-media/
 
 # IDE / editor configs
 .vscode/


### PR DESCRIPTION
## What has been done

It has been removed the /media folder from `.dockerignore` to be able to load images and other stuff in production at Render.